### PR TITLE
feat: Remove BACKEND_URL constant from callBackendApi utility  BREAKI…

### DIFF
--- a/lib/utils/callBackendApi.ts
+++ b/lib/utils/callBackendApi.ts
@@ -7,7 +7,6 @@ const BACKEND_URL = assertENV(
 );
 
 const callBackendApi = callApi.create({
-	cache: "no-store",
 	baseURL: BACKEND_URL,
 });
 


### PR DESCRIPTION
…NG CHANGE: The BACKEND_URL constant has been removed from the callBackendApi utility. Consumers of this utility will need to provide the baseURL option when calling callApi.create().