### PR TITLE
feat: Refactor form input and textarea components

### DIFF
--- a/components/common/Show.tsx
+++ b/components/common/Show.tsx
@@ -3,18 +3,23 @@
 import { getOtherChildren, getSlotElement } from "@zayne-labs/toolkit/react";
 
 type ShowProps = {
-	when: boolean;
 	children: React.ReactNode;
 	fallback?: React.ReactNode;
+	when: boolean;
 };
 
-function Show({ when, children, fallback }: ShowProps) {
+function Show({ children, fallback, when }: ShowProps) {
 	const fallBackSlot = getSlotElement(children, ShowFallback, {
-		throwOnMultipleSlotMatch: true,
 		errorMessage: "Only one <Show.Default> component is allowed",
+		throwOnMultipleSlotMatch: true,
 	});
 
-	const otherChildren = getOtherChildren(children, [ShowFallback]);
+	const contentSlot = getSlotElement(children, ShowContent, {
+		errorMessage: "Only one <Show.Content> component is allowed",
+		throwOnMultipleSlotMatch: true,
+	});
+
+	const otherChildren = getOtherChildren(children, [ShowFallback, ShowContent]);
 
 	if (fallBackSlot && fallback) {
 		throw new Error(`
@@ -23,8 +28,13 @@ function Show({ when, children, fallback }: ShowProps) {
 		`);
 	}
 
-	return when ? otherChildren : (fallBackSlot ?? fallback);
+	return when ? (contentSlot ?? otherChildren) : (fallBackSlot ?? fallback);
 }
+
+function ShowContent({ children }: Pick<ShowProps, "children">) {
+	return children;
+}
+ShowContent.slot = Symbol.for("content");
 
 function ShowFallback({ children }: Pick<ShowProps, "children">) {
 	return children;
@@ -32,5 +42,6 @@ function ShowFallback({ children }: Pick<ShowProps, "children">) {
 ShowFallback.slot = Symbol.for("fallback");
 
 Show.Fallback = ShowFallback;
+Show.Content = ShowContent;
 
 export default Show;

--- a/components/ui/form.tsx
+++ b/components/ui/form.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { cnMerge } from "@/lib/utils/cn";
 import {
 	createCustomContext,

--- a/components/ui/form.tsx
+++ b/components/ui/form.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import { cnMerge } from "@/lib/utils/cn";
 import {
 	createCustomContext,
@@ -162,24 +160,22 @@ const inputTypesWithoutFullWith = new Set<React.HTMLInputTypeAttribute>(["checkb
 function FormInputPrimitive<TFieldValues extends FieldValues>(
 	props: FormInputPrimitiveProps<TFieldValues>
 ) {
+	const contextValues = useFormItemContext();
+
 	const {
 		className,
 		classNames,
 		control,
 		errorClassName,
 		formState,
-		id: idPrimitive,
-		name: namePrimitive,
+		// eslint-disable-next-line react/no-unstable-default-props
+		id = contextValues.uniqueId,
+		// eslint-disable-next-line react/no-unstable-default-props
+		name = contextValues.name,
 		type = "text",
 		withEyeIcon = true,
 		...restOfProps
 	} = props;
-
-	const contextValues = useFormItemContext();
-
-	const name = namePrimitive ?? contextValues.name;
-
-	const id = idPrimitive ?? contextValues.uniqueId;
 
 	const getFormState = (control ? useFormState : () => formState) as typeof useFormState;
 
@@ -229,19 +225,16 @@ function FormInputPrimitive<TFieldValues extends FieldValues>(
 	);
 }
 
-function FormInput(props: Omit<FormInputPrimitiveProps, "control" | "formState" | "id" | "name">) {
+function FormInput(props: Omit<FormInputPrimitiveProps, "control" | "formState" | "id" | "name" | "ref">) {
 	const { name } = useFormItemContext();
 	const { formState, register } = useHookFormContext();
-
-	const { ref, ...restOfProps } = props;
 
 	return (
 		<FormInputPrimitive
 			name={name}
 			formState={formState}
 			{...(Boolean(name) && register(name))}
-			{...(Boolean(ref) && { ref })}
-			{...restOfProps}
+			{...props}
 		/>
 	);
 }
@@ -258,21 +251,19 @@ type FormTextAreaPrimitiveProps<TFieldValues extends FieldValues = FieldValues> 
 function FormTextAreaPrimitive<TFieldValues extends FieldValues>(
 	props: FormTextAreaPrimitiveProps<TFieldValues>
 ) {
+	const contextValues = useFormItemContext();
+
 	const {
 		className,
 		control,
 		errorClassName,
 		formState,
-		id: idPrimitive,
-		name: namePrimitive,
+		// eslint-disable-next-line react/no-unstable-default-props
+		id = contextValues.uniqueId,
+		// eslint-disable-next-line react/no-unstable-default-props
+		name = contextValues.name,
 		...restOfProps
 	} = props;
-
-	const contextValues = useFormItemContext();
-
-	const name = namePrimitive ?? contextValues.name;
-
-	const id = idPrimitive ?? contextValues.uniqueId;
 
 	const getFormState = (control ? useFormState : () => formState) as typeof useFormState;
 
@@ -293,20 +284,19 @@ function FormTextAreaPrimitive<TFieldValues extends FieldValues>(
 	);
 }
 
-function FormTextArea(props: Omit<FormTextAreaPrimitiveProps, "control" | "formState" | "id" | "name">) {
+function FormTextArea(
+	props: Omit<FormTextAreaPrimitiveProps, "control" | "formState" | "id" | "name" | "ref">
+) {
 	const { name } = useFormItemContext();
 
 	const { formState, register } = useHookFormContext();
-
-	const { ref, ...restOfProps } = props;
 
 	return (
 		<FormTextAreaPrimitive
 			name={name}
 			formState={formState}
 			{...(Boolean(name) && register(name))}
-			{...(Boolean(ref) && { ref })}
-			{...restOfProps}
+			{...props}
 		/>
 	);
 }


### PR DESCRIPTION
BREAKING CHANGE: The `id` and `name` props are now optional and will default to the values from the form item context if not provided.

- Refactored `FormInputPrimitive` and `FormTextAreaPrimitive` components to use the form item context values for `id` and `name` props if not provided
- Removed the `ref` prop from the `FormInput` and `FormTextArea` components as it was not being used
- Added a new `ShowContent` component to the `Show` component to allow rendering content when the `when` prop is true